### PR TITLE
Update gold gradient orientation

### DIFF
--- a/src/common/components/announcement/announcement.svelte
+++ b/src/common/components/announcement/announcement.svelte
@@ -5,15 +5,15 @@
 
 <div
   class="my-1.5 p-1.5"
-  style="background: linear-gradient(to right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+  style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
 >
   <div class="flex">
-    <div class="text-white text-sm flex items-center w-2/6 border-r-2">
+    <div class="text-black text-sm flex items-center w-2/6 border-r-2">
       <span class="mr-1">ประกาศจากทางเว็บ</span>
       <Volume2 size={18} />
     </div>
     <div class="px-1.5 marquee w-4/6">
-      <span class="text-sm text-white marquee-content">{details}</span>
+      <span class="text-sm text-black marquee-content">{details}</span>
     </div>
   </div>
 </div>

--- a/src/common/components/cardLotto/buttonCardLotto.svelte
+++ b/src/common/components/cardLotto/buttonCardLotto.svelte
@@ -25,15 +25,15 @@
   >
     <div
       class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform group-hover:translate-x-0.5 group-hover:translate-y-0.5"
-      style="background: linear-gradient(to bottom right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+      style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
     ></div>
     <div
       class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform"
-      style="background: linear-gradient(to bottom right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+      style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
     ></div>
     <div class="relative flex items-center justify-center">
       <span
-        class="text-white text-xs sm:text-sm group-hover:scale-105 transition-transform duration-300"
+        class="text-black text-xs sm:text-sm group-hover:scale-105 transition-transform duration-300"
       >
         {text}
       </span>

--- a/src/common/components/cardLotto/cardLotto.svelte
+++ b/src/common/components/cardLotto/cardLotto.svelte
@@ -103,8 +103,8 @@
 <div
   class="card w-full max-w-sm mx-auto overflow-hidden transition-all duration-300 ease-in-out transform hover:shadow-lg"
 >
-  <div class="rounded-t-xl relative p-4" 
-  style="background: linear-gradient(to right, {primary_color}, {secondary_color})">
+  <div class="rounded-t-xl relative p-4"
+  style="background: linear-gradient(to top, {primary_color}, {secondary_color})">
     {#if headerImageBackground}
       <img
         src={headerImageBackground}

--- a/src/common/components/navbar/navbar.svelte
+++ b/src/common/components/navbar/navbar.svelte
@@ -10,7 +10,7 @@
   <Navigation />
   <div
     class="w-full"
-    style="background: linear-gradient(to right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
   >
     <div>
       <CoreNavbar {name} {credits} {currency} />

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -135,16 +135,15 @@
         <div class="space-y-4 mb-4">
             <h1 class="text-lg font-bold my-2 text-gray-800">ประวัติการซื้อ</h1>
 
-            <div class="flex items-center text-white mt-4">
+            <div class="flex items-center text-black mt-4">
                 <button
                     class="rounded-md p-2"
-                    style="background: linear-gradient(to right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+                    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
                     class:opacity-75={lottoResult !== "PENDING"}
                     on:click={() => handleFilterChange("PENDING")}
                 >
                     <div
-                        class="text-amber
-                    -300 font-bold text-sm flex items-center"
+                        class="text-black font-bold text-sm flex items-center"
                     >
                         <p>ยังไม่ออกผล</p>
                     </div>
@@ -152,13 +151,12 @@
 
                 <button
                     class="rounded-md p-2 ml-2"
-                    style="background: linear-gradient(to right, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+                    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
                     class:opacity-75={lottoResult !== "CLOSED"}
                     on:click={() => handleFilterChange("CLOSED")}
                 >
                     <div
-                        class="text-amber
-                    -300 font-bold text-sm flex items-center"
+                        class="text-black font-bold text-sm flex items-center"
                     >
                         <p>ออกผลแล้ว</p>
                     </div>


### PR DESCRIPTION
## Summary
- use vertical gold gradient for navbar, announcement, cardLotto, and history buttons
- ensure black text is used on gold backgrounds
- orient cardLotto gradient to top

## Testing
- `npm run check` *(fails: svelte-kit not found)*