### PR TITLE
Fix null token handling for seamless login

### DIFF
--- a/src/lib/utils/user-auth.ts
+++ b/src/lib/utils/user-auth.ts
@@ -4,8 +4,10 @@ export function userAuth() {
     try {
         // check Auth
         const token = localStorage.getItem("token");
-        if (token === 'null') {
+        if (!token || token === 'null') {
+            localStorage.removeItem('token');
             goto("/seamless");
+            return;
         }
 
         // decode token

--- a/src/lib/utils/user_auth.ts
+++ b/src/lib/utils/user_auth.ts
@@ -4,8 +4,10 @@ export function userAuth() {
     try {
         // check Auth
         const token = localStorage.getItem("token");
-        if (token === 'null') {
+        if (!token || token === 'null') {
+            localStorage.removeItem('token');
             goto("/seamless");
+            return;
         }
 
         // decode token

--- a/src/routes/seamless/+layout.svelte
+++ b/src/routes/seamless/+layout.svelte
@@ -17,9 +17,11 @@
   const login = async (): Promise<void> => {
     try {
       const queryParams = Object.fromEntries($page.url.searchParams.entries());
-      const tokenValue = queryParams.token ?? $token;
+      const queryToken = queryParams.token;
+      const tokenValue =
+        queryToken && queryToken !== 'null' ? queryToken : $token;
 
-      if (tokenValue) {
+      if (tokenValue && tokenValue !== 'null') {
         token.set(tokenValue);
 
         const responseGetUsers = await loginApi.getUsers(tokenValue);
@@ -35,6 +37,8 @@
         if ($username) {
           isLoggedIn = true;
         }
+      } else {
+        token.set('');
       }
     } catch (error) {
       console.error("Error in login:", error);

--- a/src/routes/seamless/auth.store.ts
+++ b/src/routes/seamless/auth.store.ts
@@ -2,9 +2,15 @@ import { writable } from 'svelte/store';
 
 const browser = typeof window !== 'undefined';
 
-export const token = writable(browser ? localStorage.getItem('token') ?? '' : '');
-export const username = writable(browser ? localStorage.getItem('username') ?? '' : '');
-export const agent_name = writable(browser ? localStorage.getItem('agent_name') ?? '' : '');
+function getLocal(key: string): string {
+    if (!browser) return '';
+    const value = localStorage.getItem(key);
+    return value && value !== 'null' ? value : '';
+}
+
+export const token = writable(getLocal('token'));
+export const username = writable(getLocal('username'));
+export const agent_name = writable(getLocal('agent_name'));
 export const agent_id = writable<string | null>(null);
 
 let tokenValue = '';
@@ -14,17 +20,29 @@ let agentNameValue = '';
 if (browser) {
     token.subscribe(value => {
         tokenValue = value;
-        if (value) localStorage.setItem('token', value);
+        if (value) {
+            localStorage.setItem('token', value);
+        } else {
+            localStorage.removeItem('token');
+        }
     });
 
     username.subscribe(value => {
         usernameValue = value;
-        if (value) localStorage.setItem('username', value);
+        if (value) {
+            localStorage.setItem('username', value);
+        } else {
+            localStorage.removeItem('username');
+        }
     });
 
     agent_name.subscribe(value => {
         agentNameValue = value;
-        if (value) localStorage.setItem('agent_name', value);
+        if (value) {
+            localStorage.setItem('agent_name', value);
+        } else {
+            localStorage.removeItem('agent_name');
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- handle 'null' token value in seamless layout
- sanitize persisted credentials in auth store
- add validation for token in userAuth utilities

## Testing
- `npm run check` *(fails: svelte-kit not found)*