### PR TITLE
Add shared button/input styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,88 @@
 @tailwind utilities;
 
 
+/* Global theme colors */
+:root {
+  --color-bg: #1a1a1a;
+  --color-text: #ffffff;
+  --color-gold: #dab768;
+  --color-gold-light: #fef7b2;
+  --color-gold-dark: #a77338;
+  --color-announcement-bg: #734b10;
+}
+
+body {
+  @apply bg-[var(--color-bg)] text-[var(--color-text)];
+}
+
+.bg-theme {
+  background-color: var(--color-bg);
+}
+
+.text-theme {
+  color: var(--color-text);
+}
+
+.border-theme {
+  border-color: var(--color-text);
+}
+
+.text-gold {
+  color: var(--color-gold);
+}
+
+.border-gold {
+  border-color: var(--color-gold);
+}
+
+.bg-gold-gradient {
+  background: linear-gradient(
+    to top,
+    var(--color-gold-dark),
+    var(--color-gold),
+    var(--color-gold-light),
+    var(--color-gold),
+    var(--color-gold-dark)
+  );
+}
+
+.bg-gold-gradient-right {
+  background: linear-gradient(
+    to right,
+    var(--color-gold-dark),
+    var(--color-gold),
+    var(--color-gold-light),
+    var(--color-gold),
+    var(--color-gold-dark)
+  );
+}
+
+.bg-gold-gradient-simple {
+  background: linear-gradient(
+    to top,
+    var(--color-gold-light),
+    var(--color-gold),
+    var(--color-gold-dark)
+  );
+}
+
+.bg-announcement {
+  background: linear-gradient(to top, var(--color-announcement-bg));
+}
+
 .my-input {
-    @apply focus:ring-1 focus:outline-none focus:ring-red-500 focus:border-red-500 transition duration-150 ease-in-out;
+  @apply focus:ring-1 focus:outline-none focus:ring-red-500 focus:border-red-500 transition duration-150 ease-in-out;
+}
+
+/* Base input and button styles for consistent look */
+.input {
+  @apply px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-red-500 bg-black bg-opacity-75;
+}
+
+.btn {
+  @apply rounded-md font-semibold transition-colors duration-200;
+}
+
+.btn-gradient {
+  @apply btn bg-gold-gradient-right text-black;
 }

--- a/src/common/components/announcement/announcement.svelte
+++ b/src/common/components/announcement/announcement.svelte
@@ -4,8 +4,7 @@
 </script>
 
 <div
-  class="my-1.5 p-1.5"
-  style="background: linear-gradient(to top, #734b10);"
+  class="my-1.5 p-1.5 bg-announcement"
 >
   <div class="flex">
     <div class="text-white text-sm flex items-center w-2/6 border-r-2">

--- a/src/common/components/bet/BetSummary/betRow.svelte
+++ b/src/common/components/bet/BetSummary/betRow.svelte
@@ -79,7 +79,7 @@
   <td class="px-2 py-4">
     <input
       type="number"
-      class="w-20 md:w-40 px-2 py-1 border rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 transition duration-150 ease-in-out"
+      class="input w-20 md:w-40 px-2 py-1"
       value={currentAmount}
       min="1"
       on:input={handleAmountChange}
@@ -90,7 +90,7 @@
   <td class="px-2 py-4">
     <button
       on:click={handleDelete}
-      class="text-red-500 hover:text-red-700 transition-colors duration-150"
+      class="btn text-red-500 hover:text-red-700"
       title="Delete bet"
     >
       <Trash2 size={20} />

--- a/src/common/components/bet/betAmountModal.svelte
+++ b/src/common/components/bet/betAmountModal.svelte
@@ -187,7 +187,7 @@
                 <input
                     id="totalAmount"
                     type="number"
-                    class="w-full p-2 bg-gray-100 rounded text-right"
+                    class="input w-full bg-gray-100 text-right"
                     readonly
                     value={$currentBetSummary.totals.total_amount}
                 />
@@ -212,13 +212,13 @@
             <!-- Action Buttons -->
             <div class="flex justify-between gap-4">
                 <button
-                    class="flex-1 py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+                    class="btn flex-1 py-2 bg-gray-100 hover:bg-gray-200"
                     on:click={handleCloseModal}
                 >
                     ยกเลิกทั้งหมด
                 </button>
                 <button
-                    class="flex-1 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition-colors"
+                    class="btn flex-1 py-2 bg-green-500 text-white hover:bg-green-600"
                     disabled={isLoading}
                     on:click={handleSubmitBet}
                 >

--- a/src/common/components/bet/betLayout.svelte
+++ b/src/common/components/bet/betLayout.svelte
@@ -228,7 +228,7 @@
   $: enterPriceButton = totalBet == 0;
 </script>
 
-<div class="w-full mx-auto max-w-7xl bg-[#1A1A1A] min-h-screen flex flex-col items-center ">
+<div class="w-full mx-auto max-w-7xl bg-theme min-h-screen flex flex-col items-center ">
   {#if isLoading}
     <p class="text-white text-xl">กำลังโหลดข้อมูล...</p> <!-- Loading... -->
   {:else if initializationError}
@@ -237,8 +237,7 @@
       <p class="text-red-400 text-xl mb-2">เกิดข้อผิดพลาด</p> <!-- Error -->
       <p class="text-gray-300 mb-6">{initializationError}</p>
       <button
-        style="background: linear-gradient(to right, #a77338, #dab768, #fef7b2, #dab768, #a77338);"
-        class="rounded-md py-2 px-6 text-black font-bold text-sm"
+        class="btn-gradient px-6 text-sm"
         on:click={navigateBack}
       >
         กลับไปหน้าหลัก <!-- Back to Home -->
@@ -251,8 +250,7 @@
       >
         <!-- Navigation -->
         <button
-          style="background: linear-gradient(to right, #a77338, #dab768, #fef7b2, #dab768, #a77338);"
-          class="rounded-t-md mb-4 p-2 w-full"
+          class="btn-gradient rounded-t-md mb-4 p-2 w-full"
           on:click={navigateBack}
         >
           <div class="text-black font-bold text-sm flex items-center">
@@ -301,8 +299,7 @@
             </div>
             <div class="flex items-center text-white mt-4">
               <button
-                style="background: linear-gradient(to right, #a77338, #dab768, #fef7b2, #dab768, #a77338);"
-                class="rounded-md p-2"
+                class="btn-gradient p-2"
                 on:click={openLottoNumberBlockModal}
               >
                 <div class="text-black font-bold text-sm flex items-center">
@@ -311,8 +308,7 @@
               </button>
 
               <button
-                style="background: linear-gradient(to right, #a77338, #dab768, #fef7b2, #dab768, #a77338);"
-                class="rounded-md p-2 ml-2"
+                class="btn-gradient p-2 ml-2"
                 on:click={openLottoRuleModal}
               >
                 <div class="text-black font-bold text-sm flex items-center">
@@ -333,8 +329,7 @@
             <!-- Play Mode Tabs -->
             <div class="flex border-l relative justify-start mt-4">
               <button
-               style="background: linear-gradient(to right, #a77338, #dab768, #fef7b2, #dab768, #a77338);"
-                class="flex items-center justify-center text-center cursor-pointer py-2 px-3 sm:px-4 text-xs sm:text-sm border-r border-t relative border-b {selectedPlayMode
+               class="btn-gradient flex items-center justify-center text-center cursor-pointer py-2 px-3 sm:px-4 text-xs sm:text-sm border-r border-t relative border-b {selectedPlayMode
                   ? 'border-b-white'
                   : ''}"
                 on:click={() => setPlayMode("custom")}
@@ -370,13 +365,13 @@
               <div class="flex justify-center items-center mt-4 space-x-1 mb-6">
                 <button
                   on:click={betStore.clearAll}
-                  class="bg-red-500 text-white px-6 sm:px-8 py-2 rounded-lg text-sm sm:text-base"
+                  class="btn bg-red-500 text-white px-6 sm:px-8 py-2 rounded-lg text-sm sm:text-base"
                 >
                   ลบทั้งหมด
                 </button>
                 <button
                   on:click={openBetModal}
-                  class="bg-green-500 text-white px-6 sm:px-8 py-2 rounded-lg text-sm sm:text-base"
+                  class="btn bg-green-500 text-white px-6 sm:px-8 py-2 rounded-lg text-sm sm:text-base"
                   disabled={enterPriceButton}
                 >
                   ใส่ราคา

--- a/src/common/components/bet/lotteryTypeFilter.svelte
+++ b/src/common/components/bet/lotteryTypeFilter.svelte
@@ -34,8 +34,7 @@
     {#each availableBetTypes as betType}
       {#if betType.is_active}
         <button
-          style="background: linear-gradient(to top, #fef7b2, #dab768, #a77338);"
-          class="p-2 rounded-lg text-md sm:text-md transition-colors duration-200 ease-in-out"
+          class="btn-gradient p-2 rounded-lg text-md sm:text-md transition-colors duration-200 ease-in-out"
           class:active={isBetTypeSelected(betType.id)}
           on:click={() => handleBetTypeClick(betType)}
           aria-pressed={isBetTypeSelected(betType.id)}

--- a/src/common/components/bet/numberPad.svelte
+++ b/src/common/components/bet/numberPad.svelte
@@ -115,10 +115,12 @@
   <div class="flex flex-wrap justify-center space-x-2 mb-4">
     {#each digits as digit, index (index)}
       <input
-        type="text"
+        type="number"
         inputmode="numeric"
-        maxlength="1"
-        class="w-12 h-12 sm:w-14 sm:h-14 border border-gray-300 rounded text-center text-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
+        min="0"
+        max="9"
+        pattern="[0-9]"
+        class="input w-12 h-12 sm:w-14 sm:h-14 text-center text-lg mb-2"
         bind:value={digits[index]}
         on:input={(event) => handleDigitInput(event, index)}
         bind:this={digitInputRefs[index]}
@@ -130,7 +132,7 @@
   >
     {#each NUMPAD_LAYOUT as value (value)}
       <button
-        class="aspect-square w-full border rounded text-base sm:text-lg font-medium transition-colors duration-200"
+        class="btn aspect-square w-full border text-base sm:text-lg"
         class:bg-teal-500={value === "สุ่ม"}
         class:bg-red-500={value === "ลบ"}
         class:bg-white={typeof value === "number"}

--- a/src/common/components/cardLotto/buttonCardLotto.svelte
+++ b/src/common/components/cardLotto/buttonCardLotto.svelte
@@ -24,12 +24,10 @@
     aria-disabled={disabled}
   >
     <div
-      class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform group-hover:translate-x-0.5 group-hover:translate-y-0.5"
-      style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+      class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform group-hover:translate-x-0.5 group-hover:translate-y-0.5 bg-gold-gradient"
     ></div>
     <div
-      class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform"
-      style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+      class="absolute inset-0 w-full h-full transition-all duration-300 ease-out transform bg-gold-gradient"
     ></div>
     <div class="relative flex items-center justify-center">
       <span

--- a/src/common/components/lottoList/lottoList.svelte
+++ b/src/common/components/lottoList/lottoList.svelte
@@ -110,15 +110,12 @@
 </div>
 
 <style>
-  :root {
-    --gold: #dab768;
-  }
-
+  /* Gold colors defined globally in app.css */
   .text-gold {
-    color: var(--gold);
+    color: var(--color-gold);
   }
 
   .border-gold {
-    border-color: var(--gold);
+    border-color: var(--color-gold);
   }
 </style>

--- a/src/common/components/navbar/coreNavbar.svelte
+++ b/src/common/components/navbar/coreNavbar.svelte
@@ -58,7 +58,7 @@
                 </div>
 
                 <button
-                    class="text-white p-2 bg-black border border-gold mx-2 rounded-md cursor-pointer hover:bg-gold hover:text-black transition duration-300"
+                    class="btn text-white p-2 bg-black border border-gold mx-2 hover:bg-gold hover:text-black"
                     on:click={async () => await logout()}
                 >
                     <LogOut size={18} />
@@ -69,16 +69,12 @@
 </div>
 
 <style>
-    /* Custom gold color for consistency with navigation */
-    :root {
-        --gold: #FFD700;
-    }
-
+    /* Custom gold color defined in app.css */
     .text-gold {
-        color: var(--gold);
+        color: var(--color-gold);
     }
 
     .border-gold {
-        border-color: var(--gold);
+        border-color: var(--color-gold);
     }
 </style>

--- a/src/common/components/navbar/navbar.svelte
+++ b/src/common/components/navbar/navbar.svelte
@@ -8,10 +8,7 @@
 
 <div class="sticky w-full navbar">
   <Navigation />
-  <div
-    class="w-full"
-    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
-  >
+  <div class="w-full bg-gold-gradient">
     <div>
       <CoreNavbar {name} {credits} {currency} />
     </div>

--- a/src/routes/deposit/+page.svelte
+++ b/src/routes/deposit/+page.svelte
@@ -86,7 +86,7 @@
               </p>
               <button
                 on:click={() => copyToClipboard(bankAccount.accountNumber)}
-                class="text-blue-600 hover:text-blue-800 transition-colors"
+                class="btn text-blue-600 hover:text-blue-800"
                 title="Copy account number"
               >
                 <CopyCheck size={20} />
@@ -102,7 +102,7 @@
     <div class="mt-8 text-center">
       <p class="text-sm text-gray-600 mb-3">หลังจากโอนเงินเรียบร้อยแล้ว</p>
       <button
-        class="bg-green-500 text-white px-8 py-3 rounded-full font-medium hover:bg-green-600 transition-colors shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+        class="btn bg-green-500 text-white px-8 py-3 rounded-full font-medium hover:bg-green-600 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
       >
         แจ้งยอดฝาก
       </button>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -137,8 +137,7 @@
 
             <div class="flex items-center text-black mt-4">
                 <button
-                    class="rounded-md p-2"
-                    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+                    class="btn-gradient p-2"
                     class:opacity-75={lottoResult !== "PENDING"}
                     on:click={() => handleFilterChange("PENDING")}
                 >
@@ -150,8 +149,7 @@
                 </button>
 
                 <button
-                    class="rounded-md p-2 ml-2"
-                    style="background: linear-gradient(to top, #dab768, #a77338, #fef7b2, #dab768, #a77338);"
+                    class="btn-gradient p-2 ml-2"
                     class:opacity-75={lottoResult !== "CLOSED"}
                     on:click={() => handleFilterChange("CLOSED")}
                 >

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -36,7 +36,7 @@
             type="text"
             id="username"
             bind:value={username}
-            class="w-full pl-10 pr-3 py-2 border border-rose-300 rounded-md focus:outline-none focus:ring-2 focus:ring-rose-400 bg-black bg-opacity-75"
+            class="input w-full pl-10 pr-3 border-rose-300 focus:ring-rose-400"
             placeholder="กรอกชื่อผู้ใช้"
             required
           />
@@ -55,7 +55,7 @@
             type="password"
             id="password"
             bind:value={password}
-            class="w-full pl-10 pr-3 py-2 border border-rose-300 rounded-md focus:outline-none focus:ring-2 focus:ring-rose-400 bg-black bg-opacity-75"
+            class="input w-full pl-10 pr-3 border-rose-300 focus:ring-rose-400"
             placeholder="กรอกรหัสผ่าน"
             required
           />
@@ -63,7 +63,7 @@
       </div>
       <button
         type="submit"
-        class="w-full bg-red-600 text-white py-2 px-4 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition duration-200 font-semibold"
+        class="btn w-full bg-red-600 text-white hover:bg-red-700 focus:ring-red-500"
       >
         เข้าสู่ระบบ
       </button>

--- a/src/routes/navigation.svelte
+++ b/src/routes/navigation.svelte
@@ -123,19 +123,13 @@
 </div>
 
 <style>
-  /* Custom gold colors */
-  :root {
-    --gold: #dab768;
-    --gold-light: #fef7b2;
-    --gold-dark: #a77338;
-  }
-
+  /* Custom gold colors are defined globally in app.css */
   .text-gold {
-    color: var(--gold);
+    color: var(--color-gold);
   }
 
   .border-gold {
-    border-color: var(--gold);
+    border-color: var(--color-gold);
   }
   .toggle-menu {
     display: none;

--- a/src/routes/withdraw/+page.svelte
+++ b/src/routes/withdraw/+page.svelte
@@ -127,12 +127,12 @@
           id="withdrawAmount"
           bind:value={withdrawalAmount}
           placeholder="ใส่จำนวนเงิน"
-          class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+          class="input w-full px-4 py-2 border-green-500 focus:ring-green-500"
         />
       </div>
       <button
         on:click={handleWithdraw}
-        class="w-full bg-gradient-to-t from-green-700 to-green-900 text-white px-6 py-2 rounded-full text-lg font-semibold hover:from-green-700 hover:to-green-900 transition-all duration-300 transform hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+        class="btn w-full bg-gradient-to-t from-green-700 to-green-900 text-white px-6 py-2 rounded-full text-lg font-semibold hover:from-green-700 hover:to-green-900 transform hover:-translate-y-1 focus:ring-green-500"
       >
         แจ้งถอน
       </button>


### PR DESCRIPTION
## Summary
- add `.btn`, `.input` and `.btn-gradient` utilities in `app.css`
- ensure one-digit numeric input in `numberPad.svelte`
- apply new classes across login, betting, and banking pages

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `npm run build` *(fails: vite not found)*