### PR TITLE
Refactor modals for dark theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -29,6 +29,12 @@ body {
   border-color: var(--color-text);
 }
 
+/* Base modal container styling */
+.modal-container {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
 .text-gold {
   color: var(--color-gold);
 }

--- a/src/common/components/bet/betAmountModal.svelte
+++ b/src/common/components/bet/betAmountModal.svelte
@@ -131,7 +131,7 @@
 </script>
 
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center">
-    <div class="w-11/12 max-w-2xl bg-black rounded-lg overflow-hidden">
+    <div class="modal-container w-11/12 max-w-2xl rounded-lg overflow-hidden">
         <!-- Header -->
         <header
             class="bg-red-600 text-white px-4 py-2 flex justify-between items-center"
@@ -158,7 +158,7 @@
         <div class="p-4 space-y-4">
             <div class="space-y-2">
                 <button
-                    class="w-full py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+                    class="w-full py-2 bg-gray-700 text-white rounded hover:bg-gray-600 transition-colors"
                     on:click={handleClearBetAmounts}
                 >
                     เคลียร์จำนวนเงิน
@@ -167,14 +167,14 @@
                 <div class="grid grid-cols-3 gap-2">
                     {#each QUICK_BET_AMOUNTS as amount}
                         <button
-                            class="py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+                            class="py-2 bg-gray-700 text-white rounded hover:bg-gray-600 transition-colors"
                             on:click={() => handleQuickBetAmount(amount)}
                         >
                             {amount}฿
                         </button>
                     {/each}
                     <button
-                        class="py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+                        class="py-2 bg-gray-700 text-white rounded hover:bg-gray-600 transition-colors"
                     >
                         ระบุ
                     </button>
@@ -187,7 +187,7 @@
                 <input
                     id="totalAmount"
                     type="number"
-                    class="input w-full bg-gray-100 text-right"
+                    class="input w-full text-right"
                     readonly
                     value={$currentBetSummary.totals.total_amount}
                 />
@@ -212,7 +212,7 @@
             <!-- Action Buttons -->
             <div class="flex justify-between gap-4">
                 <button
-                    class="btn flex-1 py-2 bg-gray-100 hover:bg-gray-200"
+                    class="btn flex-1 py-2 bg-gray-700 text-white hover:bg-gray-600"
                     on:click={handleCloseModal}
                 >
                     ยกเลิกทั้งหมด

--- a/src/common/components/bet/betLayout.svelte
+++ b/src/common/components/bet/betLayout.svelte
@@ -26,17 +26,8 @@
   import PaymentSummary from "./confirmPayment.svelte";
   import SelectedNumbers from "./selectedNumbers.svelte";
 
-  /* Timer store and state */
-  const timeRemaining = writable(0);
-  let timerInterval: ReturnType<typeof setInterval>;
-  let displayTime = "";
+  /* Countdown state */
   let timerIntervalTarget: ReturnType<typeof setInterval>;
-
-  $: {
-    const remainingMinutes = Math.floor($timeRemaining / 60);
-    const remainingSeconds = $timeRemaining % 60;
-    displayTime = `${remainingMinutes}:${remainingSeconds.toString().padStart(2, "0")}`;
-  }
 
   /* Main state */
   let isLoading = true;
@@ -48,17 +39,12 @@
   let showPaymentSummary = false;
   let order: Order | null = null;
   let lotteryRound: LottoRound | null = null;
-  let lotto_name = "";
 
   let end_bet_min = 0;
   let dateRun: string = "";
 
   const selectedBetTypeStore = writable<LottoBetType | undefined>(undefined);
   const selectedBetTypesStore = writable<LottoBetType[]>([]);
-  const selectedBetTypesCount = derived(
-    selectedBetTypesStore,
-    ($selectedBetTypesStore) => $selectedBetTypesStore?.length || 0
-  );
   const selectedBetType = derived(
     selectedBetTypeStore,
     ($selectedBetTypeStore) => $selectedBetTypeStore?.bet_type || ""
@@ -68,20 +54,6 @@
     ($selectedBetTypeStore) => $selectedBetTypeStore?.bet_digit || 3
   );
 
-  function startTimer(seconds: number) {
-    timeRemaining.set(seconds);
-    clearInterval(timerInterval);
-
-    timerInterval = setInterval(() => {
-      timeRemaining.update((time) => {
-        if (time <= 0) {
-          clearInterval(timerInterval);
-          return 0;
-        }
-        return time - 1;
-      });
-    }, 1000);
-  }
 
   onMount(async () => {
     isLoading = true;
@@ -106,11 +78,9 @@
       }
       lotteryRound = roundData;
       end_bet_min = lotteryRound.lotto.default_close_bet_minutes;
-      lotto_name = lotteryRound.lotto.lotto_name;
       let targetDate = lotteryRound.round_date;
 
       if (lotteryRound && end_bet_min >= 0) {
-        startTimer(300); // Start 5 minute countdown
         timerIntervalTarget = setInterval(() => {
           dateRun = calculateTimeLeft(targetDate, end_bet_min).formattedText;
         }, 1000);
@@ -125,7 +95,7 @@
   });
 
   onDestroy(() => {
-    clearInterval(timerIntervalTarget ?? timerInterval);
+    clearInterval(timerIntervalTarget);
   });
 
   function handleBetTypeChange(event: CustomEvent) {

--- a/src/common/components/bet/confirmPayment.svelte
+++ b/src/common/components/bet/confirmPayment.svelte
@@ -61,8 +61,8 @@
 
   /* Success handling */
   async function handlePaymentSuccess() {
-    if (paymentStatusReturn === "COMPLETED") {
-      betStore.clearAll;
+      if (paymentStatusReturn === "COMPLETED") {
+        betStore.clearAll();
       setTimeout(() => {
         window.location.reload();
       }, 3000);
@@ -112,7 +112,7 @@
     class="flex min-h-full items-center justify-center p-4 text-center sm:p-0"
   >
     <div
-      class="w-11/12 max-w-2xl bg-white rounded-lg overflow-hidden"
+      class="modal-container w-11/12 max-w-2xl rounded-lg overflow-hidden"
       in:fly={{ y: 20, duration: 200 }}
       out:fade
     >
@@ -156,7 +156,7 @@
 
       <!-- Error Message -->
       {#if error}
-        <div class="px-4 py-3 bg-red-50" transition:fade>
+        <div class="px-4 py-3 bg-red-900" transition:fade>
           <div class="flex items-center">
             <AlertCircle class="text-red-500 mr-2" size={20} />
             <p class="text-red-700">{error}</p>
@@ -168,14 +168,14 @@
         <!-- Summary Cards -->
         <div class="px-4 py-5 sm:p-6">
           <div class="grid grid-cols-2 gap-4">
-            <div class="rounded-lg bg-gray-50 p-4">
-              <p class="text-sm font-medium text-gray-500">ยอดเดิมพันรวม</p>
-              <p class="mt-1 text-2xl font-semibold text-gray-900">
+            <div class="rounded-lg bg-gray-800 p-4">
+              <p class="text-sm font-medium text-gray-300">ยอดเดิมพันรวม</p>
+              <p class="mt-1 text-2xl font-semibold text-gray-100">
                 ฿{totalBetAmount.toFixed(2)}
               </p>
             </div>
-            <div class="rounded-lg bg-gray-50 p-4">
-              <p class="text-sm font-medium text-gray-500">เรทจ่ายรวม</p>
+            <div class="rounded-lg bg-gray-800 p-4">
+              <p class="text-sm font-medium text-gray-300">เรทจ่ายรวม</p>
               <p class="mt-1 text-2xl font-semibold text-green-600">
                 ฿{totalPayout.toFixed(2)}
               </p>
@@ -184,21 +184,21 @@
 
           <!-- Bet Details -->
           <div class="mt-6">
-            <h4 class="text-sm font-medium text-gray-900">
+            <h4 class="text-sm font-medium text-gray-100">
               รายละเอียดการชำระเงิน
             </h4>
             <div class="mt-3 max-h-60 space-y-2 overflow-y-auto rounded-md">
               {#each orderDetails.orderBets as bet, index (getBetKey(bet, index))}
                 <div
-                  class="flex items-center justify-between rounded-lg bg-gray-50 px-4 py-3"
+                  class="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3"
                 >
                   <div>
-                    <p class="text-sm font-medium text-gray-900">
+                    <p class="text-sm font-medium text-gray-100">
                       {bet.bet_type_name}: <span class="text-blue-500">{bet.bet_number}</span>
                     </p>
                   </div>
                   <div>
-                    <p class="text-sm text-gray-500">
+                    <p class="text-sm text-gray-300">
                       ซื้อ: ฿{bet.bet_amount.toFixed(2)}
                     </p>
                   </div>
@@ -236,7 +236,7 @@
             <p class="text-lg font-medium text-red-600 mb-2">
               การชำระเงินล้มเหลว
             </p>
-            <p class="text-gray-600">
+            <p class="text-gray-300">
               เกิดข้อผิดพลาดในการชำระเงิน กรุณาลองใหม่อีกครั้ง
             </p>
             {#if error}
@@ -251,7 +251,7 @@
       <!-- Pending Message -->
       {#if paymentStatus === "PENDING"}
         <div
-          class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 space-x-reverse space-x-3"
+          class="bg-gray-800 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 space-x-reverse space-x-3"
         >
           <button
             type="button"
@@ -268,7 +268,7 @@
           </button>
           <button
             type="button"
-            class="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed sm:mt-0 sm:w-auto sm:text-sm"
+            class="mt-3 inline-flex w-full justify-center rounded-md border border-gray-600 bg-gray-700 px-4 py-2 text-base font-medium text-gray-200 shadow-sm hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed sm:mt-0 sm:w-auto sm:text-sm"
             on:click={handleCancel}
             disabled={isProcessing}
           >

--- a/src/common/components/bet/lotteryTypeFilter.svelte
+++ b/src/common/components/bet/lotteryTypeFilter.svelte
@@ -61,7 +61,6 @@
 
   const groupedBetTypes: GroupedBetTypes[] = groupBetType(availableBetTypes);
 
-  console.log(groupedBetTypes);
 
   function isDigitGroupSelected(digitGroup: number): boolean {
     return selectedDigitGroup === digitGroup;

--- a/src/common/components/bet/lottoNumberBlockModal.svelte
+++ b/src/common/components/bet/lottoNumberBlockModal.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center">
-    <div class="w-11/12 max-w-2xl bg-black rounded-lg overflow-hidden">
+    <div class="modal-container w-11/12 max-w-2xl rounded-lg overflow-hidden">
         <!-- Header -->
         <header
             class="bg-red-600 text-white px-4 py-2 flex justify-between items-center"
@@ -58,7 +58,7 @@
         <!-- Content -->
         <div class="p-4 space-y-1 overflow-x-auto overflow-y-auto max-h-[600px]">
             {#if lotto}
-                <div style="color: black;">
+                <div style="color: var(--color-text);">
                     <!-- รายละเอียดการเดิมพัน -->
                     <table class="border-collapse w-full">
                         <thead class="bg-red-600 text-white">

--- a/src/common/components/bet/lottoRulesModal.svelte
+++ b/src/common/components/bet/lottoRulesModal.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center">
-    <div class="w-11/12 max-w-2xl bg-white rounded-lg overflow-hidden">
+    <div class="modal-container w-11/12 max-w-2xl rounded-lg overflow-hidden">
         <!-- Header -->
         <header
             class="bg-red-600 text-white px-4 py-2 flex justify-between items-center"
@@ -71,7 +71,7 @@
                 <p>&nbsp;</p>
 
                 <!-- รายละเอียดการเดิมพัน -->
-                <div style="color: black;">
+                <div style="color: var(--color-text);">
                     <h3 class="text-lg font-bold">
                         <u>อัตราการจ่าย</u>
                     </h3>

--- a/src/common/components/bet/numberPad.svelte
+++ b/src/common/components/bet/numberPad.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import type { Readable, Writable } from "svelte/store";
+  import type { Writable } from "svelte/store";
   import { get } from "svelte/store";
   import { onMount } from "svelte";
   import { betStore } from "$lib/stores/BetStore";
   import { NUMPAD_LAYOUT } from "$lib/utils/play-utils";
-  import type { LottoBetType, Lotto } from "$lib/interface/lotto.types";
+  import type { LottoBetType } from "$lib/interface/lotto.types";
 
   export let digitsCount: number = 3;
   export let selectedBetType: string = "";

--- a/src/common/components/bet/selectedNumbers.svelte
+++ b/src/common/components/bet/selectedNumbers.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
     import { betStore } from "$lib/stores/BetStore";
     import { derived } from "svelte/store";
+    import { onMount } from "svelte";
     import { fade } from "svelte/transition";
     import { getTypeClass } from "$lib/utils/play-utils";
     import type { LottoBetType } from "$lib/interface/lotto.types";
 
     export let availableBetTypes: LottoBetType[] = [];
 
-    // clear store
-    betStore.clearAll();
+    let betGroups;
+    let totalBet = 0;
+    let enableScrolling = false;
+
+    onMount(() => {
+        betStore.clearAll();
+    });
 
     const betListSummary = derived(betStore, () => {
         const summary = betStore.getSummary();

--- a/src/lib/stores/BetStore.ts
+++ b/src/lib/stores/BetStore.ts
@@ -1,6 +1,6 @@
 import { writable, get } from "svelte/store";
-import type { BetTypeGroup, LotteryBet, BetSummary } from "../interface/bet.types";
-import type { LottoBetType, Lotto } from "../interface/lotto.types";
+import type { BetTypeGroup, BetSummary } from "../interface/bet.types";
+import type { LottoBetType } from "../interface/lotto.types";
 import { betUtils } from "../utils/bet.utils";
 import { calculateBetSummary } from "$lib/utils/bet-calculations.utils";
 


### PR DESCRIPTION
## Summary
- switch bet modals to use `modal-container` with dark colors
- adjust quick bet buttons and cancel button styling
- make confirmPayment use dark background and fix store clearing
- use dark style for lotto rules and number block modals
- add `.modal-container` helper class in global CSS

## Testing
- `npm run check` *(fails: svelte-kit not found)*